### PR TITLE
fix: Renamed all of the stuff that referenced alpha since we are no longer calling this alpha

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -6,7 +6,7 @@ import (
 	"log"
 
 	"github.com/alexflint/go-arg"
-	"github.com/lifeomic/alpha-go"
+	"github.com/lifeomic/lifeomic-go-client"
 	"github.com/mitchellh/mapstructure"
 )
 
@@ -35,7 +35,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	client, err := alpha.BuildAlphaClient("lifeomic", args.User, map[string]bool{})
+	client, err := lo_client.BuildClient("lifeomic", args.User, map[string]bool{})
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/lifeomic/alpha-go
+module github.com/lifeomic/lifeomic-go-client
 
 go 1.17
 

--- a/lo-client.go
+++ b/lo-client.go
@@ -1,4 +1,4 @@
-package alpha
+package lo_client
 
 import (
 	"context"
@@ -34,14 +34,14 @@ type responseBody struct {
 	} `json:"errors"`
 }
 
-type Alpha struct {
+type Client struct {
 	c       *lambda.Client
 	account string
 	user    string
 	rules   map[string]bool
 }
 
-func (client *Alpha) build_gql_query(path string, query string, variables map[string]interface{}) []byte {
+func (client *Client) build_gql_query(path string, query string, variables map[string]interface{}) []byte {
 	type Body struct {
 		Query     string                 `json:"query"`
 		Variables map[string]interface{} `json:"variables"`
@@ -74,7 +74,7 @@ func parseUri(uri string) (*string, *string, error) {
 	return &functionName, &path, nil
 }
 
-func (client *Alpha) Gql(uri string, query string, variables map[string]interface{}) (*map[string]interface{}, error) {
+func (client *Client) Gql(uri string, query string, variables map[string]interface{}) (*map[string]interface{}, error) {
 	functionName, path, err := parseUri(uri)
 	if err != nil {
 		return nil, err
@@ -105,11 +105,11 @@ func (client *Alpha) Gql(uri string, query string, variables map[string]interfac
 	return &body.Data, nil
 }
 
-func BuildAlphaClient(account string, user string, rules map[string]bool) (*Alpha, error) {
+func BuildClient(account string, user string, rules map[string]bool) (*Client, error) {
 	cfg, err := config.LoadDefaultConfig(context.Background())
 	if err != nil {
 		return nil, err
 	}
-	client := Alpha{c: lambda.NewFromConfig(cfg), user: user, rules: rules, account: account}
+	client := Client{c: lambda.NewFromConfig(cfg), user: user, rules: rules, account: account}
 	return &client, nil
 }


### PR DESCRIPTION
I'm not super familiar with go naming conventions so it's totally possible I screwed this up and I'm happy to change it if folks don't like it 👍.

I followed the aws convention of just calling the struct `Client` and then referencing it by the package name `lo_client.Client` like `lambda.Client`.